### PR TITLE
Fix a deserialization bug with rollup numbers.

### DIFF
--- a/src/objects/page.rs
+++ b/src/objects/page.rs
@@ -187,7 +187,7 @@ pub enum RollupPropertyValue {
     },
     Number {
         function: RollupFunction,
-        number: Number,
+        number: Option<Number>,
     },
     Unsupported {
         function: RollupFunction,

--- a/src/objects/property.rs
+++ b/src/objects/property.rs
@@ -131,7 +131,7 @@ pub struct RelationPropertyValue {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RollupPropertyValue {
     String { string: Option<String> },
-    Number { number: Number },
+    Number { number: Option<Number> },
     Date { date: DateTime<Utc> },
     Array { results: Vec<RollupPropertyValue> },
 }


### PR DESCRIPTION
Field `number` can be null.