### PR TITLE
fix: the Notion api limits how deeply children can be nested

### DIFF
--- a/src/objects/block.rs
+++ b/src/objects/block.rs
@@ -136,6 +136,7 @@ pub struct BreadcrumpValue {}
 pub struct BulletedListItemValue {
     pub rich_text: Vec<RichText>,
     pub color: TextColor,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -213,6 +214,7 @@ pub struct LinkPreviewValue {
 pub struct NumberedListItemValue {
     pub rich_text: Vec<RichText>,
     pub color: TextColor,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -221,6 +223,7 @@ pub struct NumberedListItemValue {
 pub struct ParagraphValue {
     pub rich_text: Vec<RichText>,
     pub color: Option<TextColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -235,12 +238,14 @@ pub struct PdfValue {
 pub struct QuoteValue {
     pub rich_text: Vec<RichText>,
     pub color: TextColor,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct SyncedBlockValue {
     pub synced_from: SyncedFrom,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -255,6 +260,7 @@ pub struct TableValue {
     pub table_width: u32,
     pub has_column_header: bool,
     pub has_row_header: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -271,6 +277,7 @@ pub struct TableOfContentsValue {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct TemplateValue {
     pub rich_text: Vec<RichText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -280,6 +287,7 @@ pub struct ToDoValue {
     pub rich_text: Vec<RichText>,
     pub checked: Option<bool>,
     pub color: Option<TextColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 
@@ -287,6 +295,7 @@ pub struct ToDoValue {
 pub struct ToggleValue {
     pub rich_text: Vec<RichText>,
     pub color: TextColor,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }
 


### PR DESCRIPTION
Furthermore, at the bottom limit of the nesting, it wants the children field on the lowest-level items to be absent, and not an empty list or null. To work around this, we tell serde to skip serializing that field if it's None, which allows the caller to set the field to None in this case and get the desired behavior from the Notion API.

The first paragraph of the size limits section of the Notion API docs goes into the details of the response you'll see if you exceed the allowed depth. This depth isn't documented, but experimentation reveals that it's 3.

https://developers.notion.com/reference/request-limits#size-limits