### PR TITLE
add BlockType::Unsupported variant.

### DIFF
--- a/src/objects/block.rs
+++ b/src/objects/block.rs
@@ -121,6 +121,7 @@ pub enum BlockType {
     LinkToPage {
         link_to_page: Parent,
     },
+    Unsupported
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -606,6 +607,7 @@ impl BlockType {
             }
             BlockType::Video { video: _ } => vec![],
             BlockType::LinkToPage { link_to_page: _ } => vec![],
+            BlockType::Unsupported => vec![],
         }
     }
 }

--- a/src/objects/block.rs
+++ b/src/objects/block.rs
@@ -121,7 +121,7 @@ pub enum BlockType {
     LinkToPage {
         link_to_page: Parent,
     },
-    Unsupported
+    Unsupported,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]


### PR DESCRIPTION
I was getting serde_json deserialization errors when making requests for Blocks because notion-client did not know how to parse Unsupported Block types. The Notion API docs describe how the API only supports a subset of the Blocks that are possible, and for those that it doesn't support it returns type: unsupported