### PR TITLE
Remove unnecessary `Arc` around `reqwest::Client`

### DIFF
--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::{
     header::{self, HeaderMap, HeaderValue},
     ClientBuilder,
@@ -55,9 +53,8 @@ impl Client {
         let client = builder
             .unwrap()
             .build()
-            .map_err(|e| NotionClientError::FailedToBuildRequest { source: e });
-
-        let client = Arc::new(client.unwrap());
+            .map_err(|e| NotionClientError::FailedToBuildRequest { source: e })
+            .unwrap();
 
         Ok(Self {
             blocks: BlocksEndpoint {

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -53,8 +53,7 @@ impl Client {
         let client = builder
             .unwrap()
             .build()
-            .map_err(|e| NotionClientError::FailedToBuildRequest { source: e })
-            .unwrap();
+            .map_err(|e| NotionClientError::FailedToBuildRequest { source: e })?;
 
         Ok(Self {
             blocks: BlocksEndpoint {

--- a/src/endpoints/blocks.rs
+++ b/src/endpoints/blocks.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::Client;
 
 pub mod append;
@@ -11,5 +9,5 @@ pub mod update;
 
 #[derive(Debug, Clone)]
 pub struct BlocksEndpoint {
-    pub(super) client: Arc<Client>,
+    pub(super) client: Client,
 }

--- a/src/endpoints/comments.rs
+++ b/src/endpoints/comments.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::Client;
 
 pub mod create;
@@ -9,5 +7,5 @@ mod tests;
 
 #[derive(Debug, Clone)]
 pub struct CommentsEndpoint {
-    pub(super) client: Arc<Client>,
+    pub(super) client: Client,
 }

--- a/src/endpoints/databases.rs
+++ b/src/endpoints/databases.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::Client;
 
 pub mod create;
@@ -11,5 +9,5 @@ pub mod update;
 
 #[derive(Debug, Clone)]
 pub struct DatabasesEndpoint {
-    pub(super) client: Arc<Client>,
+    pub(super) client: Client,
 }

--- a/src/endpoints/pages.rs
+++ b/src/endpoints/pages.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::Client;
 
 pub mod create;
@@ -10,5 +8,5 @@ pub mod update;
 
 #[derive(Debug, Clone)]
 pub struct PagesEndpoint {
-    pub(super) client: Arc<Client>,
+    pub(super) client: Client,
 }

--- a/src/endpoints/search.rs
+++ b/src/endpoints/search.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::Client;
 
 #[cfg(test)]
@@ -8,5 +6,5 @@ pub mod title;
 
 #[derive(Debug, Clone)]
 pub struct SearchEndpoint {
-    pub(super) client: Arc<Client>,
+    pub(super) client: Client,
 }

--- a/src/endpoints/users.rs
+++ b/src/endpoints/users.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use reqwest::Client;
 
 pub mod list;
@@ -9,5 +7,5 @@ mod tests;
 
 #[derive(Debug, Clone)]
 pub struct UsersEndpoint {
-    pub(super) client: Arc<Client>,
+    pub(super) client: Client,
 }


### PR DESCRIPTION
Per `reqwest` docs: https://docs.rs/reqwest/0.11.24/reqwest/struct.Client.html
> The Client holds a connection pool internally, so it is advised that you create one and reuse it.
> You do **not** have to wrap the Client in an Rc or Arc to reuse it, because it already uses an Arc internally.

Also removes an unwrap that be converted into a `?`.