### PR TITLE
add support for LinkMention variant of Mention enum.

### DIFF
--- a/src/endpoints/blocks/tests.rs
+++ b/src/endpoints/blocks/tests.rs
@@ -122,3 +122,11 @@ fn test_delete_200() {
     let result = serde_json::from_str::<Block>(include_str!("tests/delete_200.json"));
     assert!(result.is_ok())
 }
+
+#[test]
+fn test_link_mention_mention_deserialization() {
+    let result = serde_json::from_str::<Block>(include_str!(
+        "tests/link_mention_mention_deserialization.json"
+    ));
+    assert!(result.is_ok())
+}

--- a/src/endpoints/blocks/tests/link_mention_mention_deserialization.json
+++ b/src/endpoints/blocks/tests/link_mention_mention_deserialization.json
@@ -1,0 +1,123 @@
+{
+  "archived": false,
+  "created_by": {
+    "id": "5be127e8-c6d7-4a7b-a46d-a0eb3bc9d6af",
+    "object": "user"
+  },
+  "created_time": "2024-09-12T11:28:00.000Z",
+  "has_children": false,
+  "id": "986dad44-69dd-408a-9b5c-678dd8cab7f3",
+  "in_trash": false,
+  "last_edited_by": {
+    "id": "5be127e8-c6d7-4a7b-a46d-a0eb3bc9d6af",
+    "object": "user"
+  },
+  "last_edited_time": "2024-09-12T11:29:00.000Z",
+  "object": "block",
+  "paragraph": {
+    "color": "default",
+    "rich_text": [
+      {
+        "annotations": {
+          "bold": false,
+          "code": false,
+          "color": "default",
+          "italic": false,
+          "strikethrough": false,
+          "underline": false
+        },
+        "href": null,
+        "plain_text": "Found a great read about ",
+        "text": {
+          "content": "Found a great read about ",
+          "link": null
+        },
+        "type": "text"
+      },
+      {
+        "annotations": {
+          "bold": false,
+          "code": false,
+          "color": "default",
+          "italic": false,
+          "strikethrough": false,
+          "underline": false
+        },
+        "href": "https://www.notion.so/2e596511572a414caf28bc18da70cc7b",
+        "mention": {
+          "page": {
+            "id": "2e596511-572a-414c-af28-bc18da70cc7b"
+          },
+          "type": "page"
+        },
+        "plain_text": "digital democracy",
+        "type": "mention"
+      },
+      {
+        "annotations": {
+          "bold": false,
+          "code": false,
+          "color": "default",
+          "italic": false,
+          "strikethrough": false,
+          "underline": false
+        },
+        "href": null,
+        "plain_text": " ",
+        "text": {
+          "content": " ",
+          "link": null
+        },
+        "type": "text"
+      },
+      {
+        "annotations": {
+          "bold": false,
+          "code": false,
+          "color": "default",
+          "italic": false,
+          "strikethrough": false,
+          "underline": false
+        },
+        "href": "https://open.substack.com/pub/extelligence/p/introduction-to-a-boring-utopia?r=j1m8&utm_medium=ios",
+        "mention": {
+          "link_mention": {
+            "description": "The following is a description of a new form of government, which I call an Algorithmic Republic.",
+            "href": "https://open.substack.com/pub/extelligence/p/introduction-to-a-boring-utopia?r=j1m8&utm_medium=ios",
+            "icon_url": "https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe9eef4cb-d8f9-4abf-9579-405c0a3a89c5%2Fapple-touch-icon-1024x1024.png",
+            "iframe_url": "https://embed.notion.co/api/iframe?app=1&theme=light&url=https%3A%2F%2Fopen.substack.com%2Fpub%2Fextelligence%2Fp%2Fintroduction-to-a-boring-utopia%3Fr%3Dj1m8%26utm_medium%3Dios&key=656ac74fac4fff346b811dca7919d483",
+            "link_author": "Some Guy",
+            "padding": 52,
+            "thumbnail_url": "https://substackcdn.com/image/fetch/f_auto,q_auto:best,fl_progressive:steep/https%3A%2F%2Fextelligence.substack.com%2Ftwitter%2Fsubscribe-card.jpg%3Fv%3D-829227407%26version%3D9",
+            "title": "Introduction to A Boring Utopia"
+          },
+          "type": "link_mention"
+        },
+        "plain_text": "https://open.substack.com/pub/extelligence/p/introduction-to-a-boring-utopia?r=j1m8&utm_medium=ios",
+        "type": "mention"
+      },
+      {
+        "annotations": {
+          "bold": false,
+          "code": false,
+          "color": "default",
+          "italic": false,
+          "strikethrough": false,
+          "underline": false
+        },
+        "href": null,
+        "plain_text": ". Sent it to ",
+        "text": {
+          "content": ". Sent it to ",
+          "link": null
+        },
+        "type": "text"
+      }
+    ]
+  },
+  "parent": {
+    "page_id": "1eee9da6-d568-42c5-bef1-311262c7aca0",
+    "type": "page_id"
+  },
+  "type": "paragraph"
+}

--- a/src/endpoints/databases/tests.rs
+++ b/src/endpoints/databases/tests.rs
@@ -193,7 +193,7 @@ fn test_create_request() {
             plain_text: None,
             href: None,
         }]),
-        properties: properties,
+        properties,
     };
 
     let result = serde_json::to_string_pretty(&request).unwrap();
@@ -294,7 +294,7 @@ fn test_update_request() {
             plain_text: None,
             href: None,
         }]),
-        properties: properties,
+        properties,
     };
 
     let result = serde_json::to_string_pretty(&request).unwrap();

--- a/src/endpoints/pages/tests.rs
+++ b/src/endpoints/pages/tests.rs
@@ -82,7 +82,7 @@ fn test_create_request() {
                     .to_string(),
             },
         }),
-        properties: properties,
+        properties,
         children: Some(vec![
             Block {
                 object: Some("block".to_string()),
@@ -142,7 +142,7 @@ fn test_update_request() {
     );
 
     let request = UpdatePagePropertiesRequest {
-        properties: properties,
+        properties,
         ..Default::default()
     };
 

--- a/src/objects/rich_text.rs
+++ b/src/objects/rich_text.rs
@@ -88,6 +88,7 @@ pub enum Mention {
     Database { database: DatabaseMention },
     Date { date: DatePropertyValue },
     LinkPreview { link_preview: LinkPreviewMention },
+    LinkMention { link_mention: LinkMentionMention },
     TemplateMention { template_mention: TemplateMention },
     Page { page: PageMention },
     User { user: User },
@@ -101,6 +102,18 @@ pub struct DatabaseMention {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct LinkPreviewMention {
     pub url: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct LinkMentionMention {
+    pub description: Option<String>,
+    pub href: Option<String>,
+    pub icon_url: Option<String>,
+    pub iframe_url: Option<String>,
+    pub link_author: Option<String>,
+    pub padding: Option<u32>,
+    pub thumbnail_url: Option<String>,
+    pub title: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]


### PR DESCRIPTION
This LinkMentionMention is a new type of block Notion recently added, but it is not documented in their API. So I'm adding it here.