### PR TITLE
update SyncedBlockValue struct to handle original and synced form.

### DIFF
--- a/src/endpoints/blocks/tests.rs
+++ b/src/endpoints/blocks/tests.rs
@@ -122,3 +122,9 @@ fn test_delete_200() {
     let result = serde_json::from_str::<Block>(include_str!("tests/delete_200.json"));
     assert!(result.is_ok())
 }
+
+#[test]
+fn test_deserialize_synced_from_block() {
+    let result = serde_json::from_str::<Vec<Block>>(include_str!("tests/synced_from_block.json"));
+    assert!(result.is_ok())
+}

--- a/src/endpoints/blocks/tests/synced_from_block.json
+++ b/src/endpoints/blocks/tests/synced_from_block.json
@@ -1,0 +1,42 @@
+[
+  {
+    "archived": false,
+    "created_by": {
+      "id": "5be127e8-c6d7-4a7b-a46d-a0eb3bc9d6af",
+      "object": "user"
+    },
+    "created_time": "2024-03-30T16:20:00.000Z",
+    "has_children": true,
+    "id": "3afef8a5-6870-453c-95b0-4f90c48b77ad",
+    "in_trash": false,
+    "last_edited_by": {
+      "id": "5be127e8-c6d7-4a7b-a46d-a0eb3bc9d6af",
+      "object": "user"
+    },
+    "last_edited_time": "2024-03-30T16:20:00.000Z",
+    "object": "block",
+    "parent": {
+      "page_id": "c870852e-d52d-4eb0-8618-a143adcad389",
+      "type": "page_id"
+    },
+    "synced_block": {
+      "synced_from": null
+    },
+    "type": "synced_block"
+  },
+  {
+    "object": "block",
+    "id": "block_id",
+    "created_time": "2021-11-17T22:17:00.000Z",
+    "last_edited_time": "2021-11-17T22:17:00.000Z",
+    "has_children": true,
+    "archived": false,
+    "type": "synced_block",
+    "synced_block": {
+      "synced_from": {
+          "type": "block_id",
+          "block_id": "3afef8a5-6870-453c-95b0-4f90c48b77ad"
+      }
+    }
+  }
+]

--- a/src/objects/block.rs
+++ b/src/objects/block.rs
@@ -245,7 +245,7 @@ pub struct QuoteValue {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct SyncedBlockValue {
-    pub synced_from: SyncedFrom,
+    pub synced_from: Option<SyncedFrom>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Block>>,
 }


### PR DESCRIPTION
According to Notion's Changelog, SyncedBlockValue's come in two forms:

https://developers.notion.com/page/changelog#synced_block-block-type

the reference form, where the synced_from object contains a block_id, was supported by notion-client prior to this commit. However the original SyncedBlockValue, where synced_from: null, was not. After this commit it will support it.