### PR TITLE
fix: deserialization of DBs with external icons

### DIFF
--- a/src/objects/database.rs
+++ b/src/objects/database.rs
@@ -4,7 +4,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use super::{emoji::Emoji, file::File, parent::Parent, rich_text::RichText, user::User};
+use super::{
+    emoji::Emoji,
+    file::{ExternalFile, File},
+    parent::Parent,
+    rich_text::RichText,
+    user::User,
+};
 
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
@@ -31,8 +37,10 @@ pub struct Database {
 pub enum Icon {
     #[default]
     None,
-    File(File),
     Emoji(Emoji),
+    External {
+        external: ExternalFile,
+    },
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
For me, [`retrieve_a_database()`](https://developers.notion.com/reference/retrieve-a-database) calls were failing with (after adding `serde_path_to_error` to help track down the error):

```
Failed to deserialize: icon: missing field `url` at line 1 column 172
```

My database responses have a value of the form:

```json
   "icon": {
      "type": "external",
      "external": { "url": "https://www.notion.so/icons/package_orange.svg" }
   },
```

I'm new to Rust and serde, so hopefully I didn't screw this up horribly; let me know if I need to improve this somehow.

---
- [x] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [x] Make your Pull Request title start with any of "fix:", "docs:", "feat:" or "BREAKING CHANGE:"
    - ref: <https://www.conventionalcommits.org/>
- [x] Ensure the tests and linter pass (Run `cargo test` to test. Run `cargo fmt --all` to format)
