### PR TITLE
fix: add HCL as allowed language in code blocks

### DIFF
--- a/src/objects/block.rs
+++ b/src/objects/block.rs
@@ -378,6 +378,7 @@ pub enum Language {
     Graphql,
     Groovy,
     Haskell,
+    HCL,
     Html,
     Java,
     Javascript,


### PR DESCRIPTION
This minor PR adds HCL (https://github.com/hashicorp/hcl) to the allowed languages list in the code blocks.